### PR TITLE
Add GitHub URL reader support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ markit schema.yaml
 # Web
 markit https://example.com/article
 markit https://en.wikipedia.org/wiki/Markdown
+markit https://github.com/TanStack/table/discussions/5834
 
 # Media (via LLMs. set OPENAI_API_KEY or ANTHROPIC_API_KEY)
 markit photo.jpg                          # EXIF metadata + AI description
@@ -58,6 +59,7 @@ markit data.xlsx -q | napkin create "Imported Data"
 | XML/SVG | `.xml` `.svg` | Code block |
 | Images | `.jpg` `.png` `.gif` `.webp` | EXIF metadata + optional AI description |
 | Audio | `.mp3` `.wav` `.m4a` `.flac` | Metadata + optional AI transcription |
+| GitHub | `github.com/*` `gist.github.com/*` | Domain-specific reader via r.jina.ai |
 | ZIP | `.zip` | Recursive. converts each file inside |
 | URLs | `http://` `https://` | Fetches with `Accept: text/markdown` |
 | Wikipedia | `*.wikipedia.org` | Main content extraction |
@@ -151,6 +153,26 @@ export default function(api: MarkitPluginAPI) {
       // Your superior PDF extraction
       return { markdown: "..." };
     },
+  });
+}
+```
+
+For site-specific URLs, plugins can also implement `convertUrl()` to bypass markit's default fetch path:
+
+```typescript
+async function readViaJina(url: string) {
+  const target = new URL(url);
+  const proxied = `https://r.jina.ai/http://${target.host}${target.pathname}${target.search}${target.hash}`;
+  const markdown = await fetch(proxied).then((res) => res.text());
+  return { markdown };
+}
+
+export default function(api: MarkitPluginAPI) {
+  api.registerConverter({
+    name: "github",
+    accepts: (info) => info.url?.includes("github.com/") ?? false,
+    convert: async (_input, info) => readViaJina(info.url!),
+    convertUrl: async (url) => readViaJina(url),
   });
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markit-ai",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markit-ai",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",
@@ -18,6 +18,7 @@
         "music-metadata": "^11.12.3",
         "rss-parser": "^3.13.0",
         "turndown": "^7.2.0",
+        "turndown-plugin-gfm": "^1.0.2",
         "unpdf": "^1.4.0"
       },
       "bin": {
@@ -66,6 +67,137 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.8.tgz",
+      "integrity": "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.8.tgz",
+      "integrity": "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.8.tgz",
+      "integrity": "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.8.tgz",
+      "integrity": "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.8.tgz",
+      "integrity": "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.8.tgz",
+      "integrity": "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.8.tgz",
+      "integrity": "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=14.21.3"
@@ -561,6 +693,12 @@
       "dependencies": {
         "@mixmark-io/domino": "^2.2.0"
       }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/src/commands/formats.ts
+++ b/src/commands/formats.ts
@@ -33,6 +33,11 @@ const BUILTIN_FORMATS: Format[] = [
     extensions: [".mp3", ".wav", ".m4a", ".flac"],
     builtin: true,
   },
+  {
+    name: "GitHub",
+    extensions: ["github.com/*", "gist.github.com/*"],
+    builtin: true,
+  },
   { name: "ZIP", extensions: [".zip"], builtin: true },
   {
     name: "Plain text",

--- a/src/converters/github.ts
+++ b/src/converters/github.ts
@@ -1,0 +1,100 @@
+import type {
+  ConversionResult,
+  Converter,
+  MarkitOptions,
+  StreamInfo,
+} from "../types.js";
+
+const GITHUB_HOSTS = new Set([
+  "github.com",
+  "www.github.com",
+  "gist.github.com",
+]);
+
+function getGitHubUrl(streamInfo: StreamInfo): URL | null {
+  if (!streamInfo.url) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(streamInfo.url);
+  } catch {
+    return null;
+  }
+
+  return GITHUB_HOSTS.has(parsed.hostname) ? parsed : null;
+}
+
+function toJinaReadUrl(url: URL): string {
+  return `https://r.jina.ai/http://${url.host}${url.pathname}${url.search}${url.hash}`;
+}
+
+function parseJinaMarkdown(text: string): ConversionResult {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const titleMatch = normalized.match(/^Title:\s*(.+)$/m);
+  const title = titleMatch?.[1]?.trim();
+
+  const bodyMatch = normalized.match(/\nMarkdown Content:\s*\n([\s\S]*)$/);
+  let markdown = bodyMatch ? bodyMatch[1].trim() : normalized;
+
+  markdown = markdown
+    .replace(/^Title:\s*.+$/m, "")
+    .replace(/^URL Source:\s*.+$/m, "")
+    .replace(/^Markdown Content:\s*$/m, "")
+    .trim();
+
+  if (title && !markdown.startsWith("# ")) {
+    markdown = `# ${title}\n\n${markdown}`;
+  }
+
+  if (!markdown) {
+    throw new Error("GitHub reader returned an empty response");
+  }
+
+  return { markdown, title };
+}
+
+async function readGitHubUrl(url: URL): Promise<ConversionResult> {
+  const response = await fetch(toJinaReadUrl(url), {
+    headers: {
+      Accept: "text/plain, text/markdown;q=0.9, */*;q=0.1",
+      "User-Agent": "markit/0.2.0",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub reader failed for ${url.toString()}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return parseJinaMarkdown(await response.text());
+}
+
+export class GitHubConverter implements Converter {
+  name = "github";
+
+  accepts(streamInfo: StreamInfo): boolean {
+    return getGitHubUrl(streamInfo) !== null;
+  }
+
+  async convert(
+    _input: Buffer,
+    streamInfo: StreamInfo,
+    _options?: MarkitOptions,
+  ): Promise<ConversionResult> {
+    const url = getGitHubUrl(streamInfo);
+    if (!url) {
+      throw new Error("GitHub converter requires a github.com URL");
+    }
+    return readGitHubUrl(url);
+  }
+
+  async convertUrl(
+    url: string,
+    streamInfo: StreamInfo,
+    _options?: MarkitOptions,
+  ): Promise<ConversionResult> {
+    const githubUrl = getGitHubUrl(streamInfo) ?? new URL(url);
+    return readGitHubUrl(githubUrl);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { AudioConverter } from "./converters/audio.js";
 export { CsvConverter } from "./converters/csv.js";
 export { DocxConverter } from "./converters/docx.js";
 export { EpubConverter } from "./converters/epub.js";
+export { GitHubConverter } from "./converters/github.js";
 export { HtmlConverter } from "./converters/html.js";
 export { ImageConverter } from "./converters/image.js";
 export { IpynbConverter } from "./converters/ipynb.js";

--- a/src/markit.test.ts
+++ b/src/markit.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Markit } from "./markit.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+describe("Markit URL conversion", () => {
+  test("uses the GitHub reader before the generic HTML fetch path", async () => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      expect(url).toBe(
+        "https://r.jina.ai/http://github.com/TanStack/table/discussions/5834#discussion-7698250",
+      );
+
+      return new Response(
+        [
+          "Title: Example Discussion",
+          "",
+          "URL Source: http://github.com/TanStack/table/discussions/5834",
+          "",
+          "Markdown Content:",
+          "## Heading",
+          "",
+          "Body",
+        ].join("\n"),
+        {
+          status: 200,
+          headers: {
+            "content-type": "text/plain; charset=utf-8",
+          },
+        },
+      );
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const markit = new Markit();
+    const result = await markit.convertUrl(
+      "https://github.com/TanStack/table/discussions/5834#discussion-7698250",
+    );
+
+    expect(result.title).toBe("Example Discussion");
+    expect(result.markdown).toBe("# Example Discussion\n\n## Heading\n\nBody");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps the default fetch path for non-GitHub URLs", async () => {
+    const fetchMock = mock(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      expect(url).toBe("https://example.com/article");
+
+      return new Response(
+        "<html><head><title>Example</title></head><body><main><h1>Hello</h1><p>World</p></main></body></html>",
+        {
+          status: 200,
+          headers: {
+            "content-type": "text/html; charset=utf-8",
+          },
+        },
+      );
+    });
+
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const markit = new Markit();
+    const result = await markit.convertUrl("https://example.com/article");
+
+    expect(result.title).toBe("Example");
+    expect(result.markdown).toContain("Hello");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/markit.ts
+++ b/src/markit.ts
@@ -4,6 +4,7 @@ import { AudioConverter } from "./converters/audio.js";
 import { CsvConverter } from "./converters/csv.js";
 import { DocxConverter } from "./converters/docx.js";
 import { EpubConverter } from "./converters/epub.js";
+import { GitHubConverter } from "./converters/github.js";
 import { HtmlConverter } from "./converters/html.js";
 import { ImageConverter } from "./converters/image.js";
 import { IpynbConverter } from "./converters/ipynb.js";
@@ -43,6 +44,7 @@ export class Markit {
       new XlsxConverter(),
       new EpubConverter(),
       new IpynbConverter(),
+      new GitHubConverter(),
       new WikipediaConverter(),
       new RssConverter(),
       new CsvConverter(),
@@ -85,6 +87,19 @@ export class Markit {
    * Convert a URL to markdown.
    */
   async convertUrl(url: string): Promise<ConversionResult> {
+    const streamInfo = createUrlStreamInfo(url);
+
+    for (const converter of this.converters) {
+      if (!converter.convertUrl) continue;
+      if (!converter.accepts(streamInfo)) continue;
+
+      try {
+        return await converter.convertUrl(url, streamInfo, this.options);
+      } catch {
+        // Fall through to the default fetch path if the URL-specific reader fails.
+      }
+    }
+
     const response = await fetch(url, {
       headers: {
         Accept: "text/markdown, text/html;q=0.9, text/plain;q=0.8, */*;q=0.1",
@@ -99,21 +114,20 @@ export class Markit {
     }
 
     const contentType = response.headers.get("content-type") || "";
-    const [mimetype] = contentType.split(";");
-
-    // Derive extension from URL path
-    const urlPath = new URL(url).pathname;
-    const ext = extname(urlPath).toLowerCase();
+    const [mimetype, ...params] = contentType.split(";");
+    const charset = params
+      .map((part) => part.trim())
+      .find((part) => part.toLowerCase().startsWith("charset="))
+      ?.slice("charset=".length);
 
     const buffer = Buffer.from(await response.arrayBuffer());
-    const streamInfo: StreamInfo = {
-      url,
+    const fetchedStreamInfo: StreamInfo = {
+      ...streamInfo,
       mimetype: mimetype.trim(),
-      extension: ext || undefined,
-      filename: basename(urlPath) || undefined,
+      charset,
     };
 
-    return this.convert(buffer, streamInfo);
+    return this.convert(buffer, fetchedStreamInfo);
   }
 
   /**
@@ -149,4 +163,16 @@ export class Markit {
       `Unsupported format: ${streamInfo.extension || streamInfo.mimetype || "unknown"}`,
     );
   }
+}
+
+function createUrlStreamInfo(url: string): StreamInfo {
+  const parsed = new URL(url);
+  const extension = extname(parsed.pathname).toLowerCase() || undefined;
+  const filename = basename(parsed.pathname) || undefined;
+
+  return {
+    url,
+    extension,
+    filename,
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,16 @@ export interface Converter {
   /** Quick check: can this converter handle the given stream? */
   accepts(streamInfo: StreamInfo): boolean;
 
+  /**
+   * Optional URL-first hook. Runs before markit fetches the URL itself.
+   * Useful for site-specific readers or alternate fetch endpoints.
+   */
+  convertUrl?(
+    url: string,
+    streamInfo: StreamInfo,
+    options?: MarkitOptions,
+  ): Promise<ConversionResult>;
+
   /** Convert the source to markdown */
   convert(
     input: Buffer,


### PR DESCRIPTION
## Summary
- add a GitHub-specific URL reader that proxies github.com and gist.github.com URLs through r.jina.ai before the generic HTML fetch path runs
- add an optional `convertUrl()` hook to the converter contract so plugins can override site-specific URL fetching
- document the new capability, expose GitHub in supported formats, and add tests covering both GitHub interception and non-GitHub fallback

## Verification
- `bun test`
- `npm run build`
- `npm run check`
- `bun run src/main.ts "https://github.com/TanStack/table/discussions/5834#discussion-7698250" | sed -n "1,120p"`

## Notes
- `package-lock.json` was regenerated because it was stale relative to the checked-in `package.json`.